### PR TITLE
Add Nemelex server (CNC)

### DIFF
--- a/apps/api/prisma/seedData.ts
+++ b/apps/api/prisma/seedData.ts
@@ -168,6 +168,25 @@ export const data = {
   ],
   servers: [
     {
+      name: 'Nemelex',
+      abbreviation: 'CNC',
+      url: 'https://crawl.nemelex.cards',
+      baseUrl: 'https://archive.nemelex.cards',
+      morgueUrl: 'https://archive.nemelex.cards/morgue',
+      logfiles: [
+        ...range(11, 32).map((version) => ({
+          path: `/meta/crawl-0.${version}/logfile`,
+          version: `0.${version}`,
+          morgueUrlPrefix: undefined,
+        })),
+        {
+          path: `/crawl/meta/crawl-git/logfile`,
+          version: 'git',
+          morgueUrlPrefix: undefined,
+        },
+      ],
+    },
+    {
       name: 'crawl.dcss.io',
       abbreviation: 'CDI',
       url: 'https://crawl.dcss.io',

--- a/apps/api/prisma/seedData.ts
+++ b/apps/api/prisma/seedData.ts
@@ -180,7 +180,7 @@ export const data = {
           morgueUrlPrefix: undefined,
         })),
         {
-          path: `/crawl/meta/crawl-git/logfile`,
+          path: `/meta/crawl-git/logfile`,
           version: 'git',
           morgueUrlPrefix: undefined,
         },


### PR DESCRIPTION
Hello, thank you for creating a wonderful scoreboard site.

Due to recent failures and instability of the CWZ server, Korean players have been inconvenienced when using Crawl webtiles.

So I have created a new server called CNC (crawl.nemelex.cards).

Currently, the server data is integrated with the CAO scoreboard and Sequell.

It would be great if the play data from CNC server could also appear on dcss-stats, which is frequently used by my server's players, so I created this PR.

It seems that the server data is handled in seedData.ts, so I added my server's data by referring to the settings of other servers.

If there is anything I need to let you know about my server configuration, I would be happy to provide that information.